### PR TITLE
Update black action to ignore migration files

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Install black and run black check
         run: |
           pip install black
-          black --check --verbose .
+          black --check --verbose --extend-exclude migrations .


### PR DESCRIPTION
Currently our Github action for checking black included migration files. We don't want to check/format migration files so this change edits the command to ignore migrations