### PR TITLE
Create Endpoints for Users and Groups

### DIFF
--- a/groups/models.py
+++ b/groups/models.py
@@ -29,6 +29,3 @@ class Member(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     group = models.ForeignKey(Group, on_delete=models.CASCADE)
     role = models.CharField(choices=Roles.choices, blank=False)
-
-    def __str__(self):
-        return f"{self.user}, {self.group}, {self.role}"

--- a/groups/serializers.py
+++ b/groups/serializers.py
@@ -12,7 +12,7 @@ class MemberSerializer(serializers.ModelSerializer):
 
 
 class GroupSerializer(serializers.ModelSerializer):
-    members = MemberSerializer(source="member_set", many=True)
+    members = serializers.SerializerMethodField()
 
     class Meta:
         model = Group
@@ -32,3 +32,20 @@ class GroupSerializer(serializers.ModelSerializer):
         Member.objects.create(user_id=user.id, group=group, role=Member.Roles.ADMIN)
 
         return group
+
+    def get_members(self, obj):
+        members = Member.objects.filter(group__member__group_id=obj.id)
+        return MemberSerializer(members, many=True).data
+
+
+class RestrictedGroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Group
+        fields = [
+            "id",
+            "name",
+            "active",
+            "schedule",
+            "logo_url",
+            "last_issue_date",
+        ]

--- a/groups/serializers.py
+++ b/groups/serializers.py
@@ -36,16 +36,3 @@ class GroupSerializer(serializers.ModelSerializer):
     def get_members(self, obj):
         members = Member.objects.filter(group_id=obj.id)
         return MemberSerializer(members, many=True).data
-
-
-class RestrictedGroupSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Group
-        fields = [
-            "id",
-            "name",
-            "active",
-            "schedule",
-            "logo_url",
-            "last_issue_date",
-        ]

--- a/groups/serializers.py
+++ b/groups/serializers.py
@@ -34,7 +34,7 @@ class GroupSerializer(serializers.ModelSerializer):
         return group
 
     def get_members(self, obj):
-        members = Member.objects.filter(group__member__group_id=obj.id)
+        members = Member.objects.filter(group_id=obj.id)
         return MemberSerializer(members, many=True).data
 
 

--- a/groups/serializers.py
+++ b/groups/serializers.py
@@ -1,0 +1,34 @@
+from rest_framework import serializers
+
+from groups.models import Group, Member
+
+
+class MemberSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="user.name")
+
+    class Meta:
+        model = Member
+        fields = ("name", "role")
+
+
+class GroupSerializer(serializers.ModelSerializer):
+    members = MemberSerializer(source="member_set", many=True)
+
+    class Meta:
+        model = Group
+        fields = [
+            "id",
+            "name",
+            "active",
+            "schedule",
+            "logo_url",
+            "last_issue_date",
+            "members",
+        ]
+
+    def create(self, validated_data):
+        user = validated_data.pop("user")
+        group = Group.objects.create(**validated_data)
+        Member.objects.create(user_id=user.id, group=group, role=Member.Roles.ADMIN)
+
+        return group

--- a/groups/tests.py
+++ b/groups/tests.py
@@ -1,0 +1,24 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from groups.models import Member
+from users.models import User
+
+
+class GroupViewSetTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(name="test_user", email="test@test.com")
+        self.client.force_authenticate(user=self.user)
+
+    def test_user_creating_group_creates_membership(self):
+        url = reverse("group-list")
+        data = {"name": "test group"}
+        response = self.client.post(url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "test group")
+        members = Member.objects.filter(group_id=response.data["id"])
+        self.assertIsNotNone(members)
+        for member in members:
+            self.assertEqual(member.user_id, self.user.id)
+            self.assertEqual(member.role, Member.Roles.ADMIN)

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,0 +1,18 @@
+from rest_framework import permissions, viewsets
+
+from groups.models import Group
+from groups.serializers import GroupSerializer
+
+
+class GroupViewSet(viewsets.ModelViewSet):
+    """
+    This viewset automatically provides `list`, `create`, retrieve`,
+    `update` and `destroy` actions.
+    """
+
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)

--- a/looping/urls.py
+++ b/looping/urls.py
@@ -14,8 +14,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
 
-urlpatterns = [
-    path("admin/", admin.site.urls),
-]
+from groups import views
+
+router = DefaultRouter()
+router.register(r"groups", views.GroupViewSet, basename="group")
+
+urlpatterns = [path("admin/", admin.site.urls), path("", include(router.urls))]

--- a/looping/urls.py
+++ b/looping/urls.py
@@ -17,9 +17,12 @@ from django.contrib import admin
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from groups import views
+from groups.views import GroupViewSet
+from users.views import UserViewSet
 
 router = DefaultRouter()
-router.register(r"groups", views.GroupViewSet, basename="group")
+router.register(r"groups", GroupViewSet, basename="group")
+router.register(r"users", UserViewSet, basename="user")
+
 
 urlpatterns = [path("admin/", admin.site.urls), path("", include(router.urls))]

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+
+from groups.models import Group
+from groups.serializers import RestrictedGroupSerializer
+from users.models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    groups = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ["id", "name", "groups", "email"]
+
+    def get_groups(self, obj):
+        groups = Group.objects.filter(member__user_id=obj.id)
+        return RestrictedGroupSerializer(groups, many=True).data

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from groups.models import Group
-from groups.serializers import RestrictedGroupSerializer
+from groups.serializers import GroupSerializer
 from users.models import User
 
 
@@ -14,4 +14,4 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_groups(self, obj):
         groups = Group.objects.filter(member__user_id=obj.id)
-        return RestrictedGroupSerializer(groups, many=True).data
+        return GroupSerializer(groups, many=True).data

--- a/users/views.py
+++ b/users/views.py
@@ -1,0 +1,10 @@
+from rest_framework import permissions, viewsets
+
+from users.models import User
+from users.serializers import UserSerializer
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
### Changes Made

- Created Serializers for Users, Groups, and Members
  - This allows our Django Model objects to be converted to and back JSON
- Created User and Group Viewsets using Django builtin Viewsets
  - This gives us CRUD endpoints for Users and Groups   