### PR TITLE
Add nested logic for adding answers and questions to newsletters

### DIFF
--- a/newsletters/serializers.py
+++ b/newsletters/serializers.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
 from newsletters.models import Answer, Newsletter, Question
@@ -52,17 +53,30 @@ class NewsletterSerializer(serializers.ModelSerializer):
         instance.status = validated_data.get("status", instance.status)
         instance.issue_date = validated_data.get("issue_date", instance.issue_date)
         questions_to_add = validated_data.pop("questions")
+
+        # Check if any questions removed from newsletter and delete any existing answers
+        questions_in_newsletter = set(
+            instance.questions.all().values_list("id", flat=True)
+        )
+        question_ids = set(q["id"] for q in questions_to_add)
+        removed_questions_ids = questions_in_newsletter - question_ids
+        for question_id in removed_questions_ids:
+            Answer.objects.filter(
+                question_id=question_id, newsletter_id=instance.id
+            ).delete()
+
         questions = []
         for question in questions_to_add:
-            q = Question.objects.get(pk=question["id"])
-            questions.append(q)
+            q = Question.objects.filter(pk=question["id"]).first()
+            if q:
+                questions.append(q)
         instance.questions.set(questions)
         instance.save()
         return instance
 
 
 class AnswerCreateSerializer(serializers.ModelSerializer):
-    question_id = serializers.IntegerField()
+    question_id = serializers.PrimaryKeyRelatedField(queryset=Question.objects.all())
 
     class Meta:
         model = Answer

--- a/newsletters/serializers.py
+++ b/newsletters/serializers.py
@@ -1,6 +1,5 @@
 import datetime
 
-from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
 from newsletters.models import Answer, Newsletter, Question


### PR DESCRIPTION
- When adding answers, checks if the question for the answer is actually part of the newsletter
- When removing questions from a newsletter, remove any related answers as well
- Can only add answers to `IN_PROGRESS` newsletters