### PR TITLE
Introduce Permissions for Groups

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Install flake8 and run flake8 lint
         run: |
           pip install flake8
-          python -m flake8 --ignore E203,E501,W504  --exclude migrations --max-line-length 88 .
+          python -m flake8 --ignore E203,E501,W503  --exclude migrations --max-line-length 88 .
 

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Install flake8 and run flake8 lint
         run: |
           pip install flake8
-          python -m flake8 --ignore E203,E501  --exclude migrations --max-line-length 88 .
+          python -m flake8 --ignore E203,E501,W504  --exclude migrations --max-line-length 88 .
 

--- a/groups/permissions.py
+++ b/groups/permissions.py
@@ -1,0 +1,32 @@
+from rest_framework import permissions
+
+from groups.models import Member
+
+
+class AdminAllButMemberReadOnly(permissions.BasePermission):
+    restricted_methods = ("PUT", "PATCH", "DELETE")
+
+    def get_membership(self, obj, user):
+        return obj.member_set.filter(user=user).first()
+
+    def has_permission(self, request, view):
+        if request.user.is_authenticated:
+            return True
+
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_superuser:
+            return True
+
+        membership = self.get_membership(obj, request.user)
+
+        if membership:
+            if request.method in permissions.SAFE_METHODS:
+                return True
+
+            if (
+                membership.role is Member.Roles.ADMIN
+                and request.method in self.restricted_methods
+            ):
+                return True
+
+        return False

--- a/groups/permissions.py
+++ b/groups/permissions.py
@@ -22,9 +22,8 @@ class AdminAllButMemberReadOnly(permissions.BasePermission):
         if membership:
             if request.method in permissions.SAFE_METHODS:
                 return True
-
             if (
-                membership.role is Member.Roles.ADMIN
+                membership.role == Member.Roles.ADMIN
                 and request.method in self.restricted_methods
             ):
                 return True

--- a/groups/tests.py
+++ b/groups/tests.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from groups.models import Member
-from utils.tests.factory import UserFactory
+from utils.tests.factory import GroupMemberFactory, UserFactory, UserWithGroupFactory
 
 
 class GroupViewSetTests(APITestCase):
@@ -22,3 +22,49 @@ class GroupViewSetTests(APITestCase):
         for member in members:
             self.assertEqual(member.user_id, self.user.id)
             self.assertEqual(member.role, Member.Roles.ADMIN)
+
+
+class AdminAllButMemberReadOnlyPermissionsTests(APITestCase):
+    def setUp(self):
+        self.user = UserWithGroupFactory()
+        self.user_with_no_group = UserFactory(email="test@test.com")
+        self.group_url = f"/groups/{self.user.group_set.first().id}/"
+        self.update_payload = {"name": "Test Update Name"}
+
+    def test_user_cannot_access_groups_without_membership(self):
+        self.client.force_authenticate(user=self.user_with_no_group)
+        response = self.client.get(self.group_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_user_can_access_group_with_membership(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.group_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_group_member_cannot_update_group(self):
+        GroupMemberFactory(
+            user=self.user_with_no_group, group=self.user.group_set.first()
+        )
+        self.client.force_authenticate(user=self.user_with_no_group)
+        response = self.client.put(self.group_url, data=self.update_payload)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_member_cannot_delete_group(self):
+        GroupMemberFactory(
+            user=self.user_with_no_group, group=self.user.group_set.first()
+        )
+        self.client.force_authenticate(user=self.user_with_no_group)
+        response = self.client.delete(self.group_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_admin_can_update_group(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.put(self.group_url, data=self.update_payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.user.group_set.first().name, self.update_payload["name"])
+
+    def test_group_admin_can_delete_group(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self.group_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIsNone(self.user.group_set.first())

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,4 +1,4 @@
-from rest_framework import permissions, viewsets
+from rest_framework import viewsets
 
 from groups.models import Group
 from groups.permissions import AdminAllButMemberReadOnly

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,6 +1,7 @@
 from rest_framework import permissions, viewsets
 
 from groups.models import Group
+from groups.permissions import AdminAllButMemberReadOnly
 from groups.serializers import GroupSerializer
 
 
@@ -12,7 +13,10 @@ class GroupViewSet(viewsets.ModelViewSet):
 
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [AdminAllButMemberReadOnly]
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
+
+    def get_queryset(self):
+        return self.queryset.filter(users=self.request.user)

--- a/magiclinklogin/authentication.py
+++ b/magiclinklogin/authentication.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth.backends import ModelBackend
 from django.core import signing
 from rest_framework import exceptions
 
@@ -6,7 +6,7 @@ from groups.models import Group, Member
 from users.models import User
 
 
-class MagicLinkBackend(BaseBackend):
+class MagicLinkBackend(ModelBackend):
     def authenticate(self, request):
         """
         Authenticates the given `email` provided in the token. If `email` does not
@@ -33,3 +33,9 @@ class MagicLinkBackend(BaseBackend):
             return user
         except Exception:
             raise exceptions.AuthenticationFailed(detail="Invalid or expired token")
+
+    def get_user(self, id):
+        try:
+            return User.objects.get(pk=id)
+        except User.DoesNotExist:
+            return None

--- a/utils/tests/factory.py
+++ b/utils/tests/factory.py
@@ -34,8 +34,21 @@ class GroupAdminFactory(factory.django.DjangoModelFactory):
     role = Member.Roles.ADMIN
 
 
+class GroupMemberFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Member
+
+    user = factory.SubFactory(UserFactory)
+    group = factory.SubFactory(GroupFactory)
+    role = Member.Roles.MEMBER
+
+
 class UserWithGroupFactory(UserFactory):
     membership = factory.RelatedFactory(GroupAdminFactory, factory_related_name="user")
+
+
+class UserWithGroupMemberFactory(UserFactory):
+    membership = factory.RelatedFactory(GroupMemberFactory, factory_related_name="user")
 
 
 class QuestionFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
This change creates Permissions for our Group Model where only Group Admin can update the group while members have read-only permissions.