### PR TITLE
Newsletter access Permissions

### DIFF
--- a/newsletters/permissions.py
+++ b/newsletters/permissions.py
@@ -4,7 +4,7 @@ from groups.models import Member
 from utils.utils import get_membership
 
 
-class AdminAllButMemberReadOnly(permissions.BasePermission):
+class NewsletterAdminAllMemberReadOnly(permissions.BasePermission):
     restricted_methods = ("PUT", "PATCH", "DELETE")
 
     def has_permission(self, request, view):
@@ -15,7 +15,7 @@ class AdminAllButMemberReadOnly(permissions.BasePermission):
         if request.user.is_superuser:
             return True
 
-        membership = get_membership(obj, request.user)
+        membership = get_membership(obj.group, request.user)
 
         if membership:
             if request.method in permissions.SAFE_METHODS:

--- a/newsletters/serializers.py
+++ b/newsletters/serializers.py
@@ -56,7 +56,7 @@ class NewsletterSerializer(serializers.ModelSerializer):
             Newsletter.Status.UPCOMING,
             Newsletter.Status.INPROGRESS,
         ):
-            questions_to_add = validated_data.pop("questions")
+            questions_to_add = validated_data.pop("questions", [])
             # Check if any questions removed from newsletter and delete existing answers
             questions_in_newsletter = set(
                 instance.questions.all().values_list("id", flat=True)

--- a/newsletters/views.py
+++ b/newsletters/views.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from newsletters.models import Answer, Newsletter, Question
+from newsletters.permissions import NewsletterAdminAllMemberReadOnly
 from newsletters.serializers import (
     AnswerCreateSerializer,
     AnswerSerializer,
@@ -15,7 +16,7 @@ from newsletters.serializers import (
 class NewsletterViewSet(viewsets.ModelViewSet):
     queryset = Newsletter.objects.all()
     serializer_class = NewsletterSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [NewsletterAdminAllMemberReadOnly]
 
 
 class AnswerViewSet(viewsets.ViewSet):

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -12,3 +12,7 @@ def calculate_next_issue_date(schedule, last_issue_date):
         next_issue_date = last_issue_date + relativedelta(months=+1)
 
     return next_issue_date
+
+
+def get_membership(group, user):
+    return group.member_set.filter(user=user).first()


### PR DESCRIPTION
- Create permission group which allows only Group admin and members to interact with a group's newsletters