### PR TITLE
Add step to install requirements.txt in github action jobs

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,7 +10,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.12"
-      - name: Install black and run black check
+      - name: Install requirements.txt
         run: |
-          pip install black
+          pip install -r requirements.txt
+      - name: Run black check
+        run: |
           black --check --verbose --extend-exclude migrations .

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -10,6 +10,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.12"
+      - name: Install requirements.txt
+        run: |
+          pip install -r requirements.txt
       - name: Install flake8 and run flake8 lint
         run: |
           pip install flake8

--- a/newsletters/views.py
+++ b/newsletters/views.py
@@ -4,6 +4,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from groups.models import Group
 from newsletters.models import Answer, Newsletter, Question
 from newsletters.permissions import IsGroupMember, NewsletterAdminAllMemberReadOnly
 from newsletters.serializers import (
@@ -20,6 +21,12 @@ class NewsletterViewSet(viewsets.ModelViewSet):
     queryset = Newsletter.objects.all()
     serializer_class = NewsletterSerializer
     permission_classes = [NewsletterAdminAllMemberReadOnly]
+
+    def get_queryset(self):
+        user_groups = Group.objects.filter(users=self.request.user).values_list(
+            "id", flat=True
+        )
+        return self.queryset.filter(group_id__in=user_groups)
 
     @action(detail=True, methods=["GET"])
     def questions(self, request, pk=None):


### PR DESCRIPTION
Previously, github actions would install the latest version of `Black` instead of the version stated in requirements.txt causing Github to raise errors where local wouldn't raise same error due to difference in versions