### PR TITLE
Add custom endpoint and tests for group questions

### DIFF
--- a/groups/tests.py
+++ b/groups/tests.py
@@ -1,20 +1,32 @@
-from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from groups.models import Member
-from utils.tests.factory import GroupMemberFactory, UserFactory, UserWithGroupFactory
+from newsletters.models import Answer
+from utils.tests.factory import (
+    AnswerFactory,
+    GroupMemberFactory,
+    NewsletterFactory,
+    QuestionFactory,
+    UserFactory,
+    UserWithGroupFactory,
+)
 
 
 class GroupViewSetTests(APITestCase):
     def setUp(self):
-        self.user = UserFactory()
+        self.user = UserWithGroupFactory()
+        self.group = self.user.group_set.first()
+        self.newsletter = NewsletterFactory(
+            group=self.group, questions=[QuestionFactory(group=self.group)]
+        )
+        self.group_url = "/groups/"
+        self.group_questions_url = f"{self.group_url}{self.group.id}/questions/"
         self.client.force_authenticate(user=self.user)
 
     def test_user_creating_group_creates_membership(self):
-        url = reverse("group-list")
         data = {"name": "test group"}
-        response = self.client.post(url, data=data)
+        response = self.client.post(self.group_url, data=data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data["name"], "test group")
         members = self.user.member_set.filter(group_id=response.data["id"])
@@ -22,6 +34,45 @@ class GroupViewSetTests(APITestCase):
         for member in members:
             self.assertEqual(member.user_id, self.user.id)
             self.assertEqual(member.role, Member.Roles.ADMIN)
+
+    def test_retrieving_group_questions_succeeds(self):
+        response = self.client.get(self.group_questions_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(self.newsletter.questions.first().id, data[0]["id"])
+
+    def test_removing_group_question_succeeds(self):
+        new_question = QuestionFactory(group=self.group)
+        response = self.client.delete(
+            f"{self.group_url}{self.group.id}/questions/{new_question.id}/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.client.get(self.group_questions_url)
+        data = response.json()
+        for q in data:
+            self.assertNotEqual(new_question.id, q["id"])
+
+    def test_removing_group_question_removes_question_from_newsletter(self):
+        new_question = QuestionFactory(group=self.group)
+        self.newsletter.questions.add(new_question)
+        self.client.delete(
+            f"{self.group_url}{self.group.id}/questions/{new_question.id}/"
+        )
+        self.newsletter.refresh_from_db()
+        for q in self.newsletter.questions.all():
+            self.assertNotEqual(new_question.id, q.id)
+
+    def test_removing_group_question_removes_answer_from_newsletter(self):
+        new_question = QuestionFactory(group=self.group)
+        self.newsletter.questions.add(new_question)
+        answer = AnswerFactory(
+            submitter=self.user, question=new_question, newsletter=self.newsletter
+        )
+        self.client.delete(
+            f"{self.group_url}{self.group.id}/questions/{new_question.id}/"
+        )
+        self.assertIsNone(Answer.objects.filter(id=answer.id).first())
 
 
 class AdminAllButMemberReadOnlyPermissionsTests(APITestCase):

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import get_object_or_404
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,8 +1,13 @@
-from rest_framework import viewsets
+from django.shortcuts import get_object_or_404
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from groups.models import Group
 from groups.permissions import AdminAllButMemberReadOnly
 from groups.serializers import GroupSerializer
+from newsletters.models import Question
+from newsletters.serializers import QuestionSerializer
 
 
 class GroupViewSet(viewsets.ModelViewSet):
@@ -20,3 +25,18 @@ class GroupViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return self.queryset.filter(users=self.request.user)
+
+    @action(detail=True, methods=["GET"])
+    def questions(self, request, pk=None):
+        group = self.get_object()
+        questions = Question.objects.filter(group_id=group.id)
+        serializer = QuestionSerializer(questions, many=True)
+        return Response(serializer.data)
+
+    @action(
+        detail=True, methods=["DELETE"], url_path="questions/(?P<question_pk>[^/.]+)"
+    )
+    def remove_question(self, request, question_pk, pk=None):
+        group = self.get_object()
+        Question.objects.filter(group_id=group.id, id=question_pk).delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
- Add a custom endpoint under the group viewset in order to interact with a group's questions