### PR TITLE
Update newsletter issue dates whenever a new newsletter is created

### DIFF
--- a/groups/serializers.py
+++ b/groups/serializers.py
@@ -1,6 +1,10 @@
+import datetime
+
 from rest_framework import serializers
 
 from groups.models import Group, Member
+from newsletters.models import Newsletter
+from utils.utils import calculate_next_issue_date
 
 
 class MemberSerializer(serializers.ModelSerializer):
@@ -32,6 +36,28 @@ class GroupSerializer(serializers.ModelSerializer):
         Member.objects.create(user_id=user.id, group=group, role=Member.Roles.ADMIN)
 
         return group
+
+    def update(self, instance, validated_data):
+        current_schedule = instance.schedule
+        new_schedule = validated_data.get("schedule", instance.schedule)
+        updated_instance = super().update(instance, validated_data)
+
+        # If we change the schedule of a group, need to update
+        # the schedule of any upcoming newsletters
+        if current_schedule != new_schedule:
+            newsletters_to_update = Newsletter.objects.filter(
+                group_id=instance.id, status=Newsletter.Status.UPCOMING
+            ).order_by("issue_date")
+            prev_issue_date = newsletters_to_update.first().issue_date
+            for newsletter in newsletters_to_update:
+                new_issue_date = calculate_next_issue_date(
+                    new_schedule, prev_issue_date
+                )
+                newsletter.issue_date = new_issue_date
+                prev_issue_date = new_issue_date
+            Newsletter.objects.bulk_update(newsletters_to_update, ["issue_date"])
+
+        return updated_instance
 
     def get_members(self, obj):
         members = Member.objects.filter(group_id=obj.id)

--- a/groups/serializers.py
+++ b/groups/serializers.py
@@ -1,5 +1,3 @@
-import datetime
-
 from rest_framework import serializers
 
 from groups.models import Group, Member

--- a/groups/tests.py
+++ b/groups/tests.py
@@ -1,8 +1,11 @@
+import datetime
+
+from dateutil import relativedelta
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from groups.models import Member
-from newsletters.models import Answer
+from groups.models import Group, Member
+from newsletters.models import Answer, Newsletter
 from utils.tests.factory import (
     AnswerFactory,
     GroupMemberFactory,
@@ -11,6 +14,86 @@ from utils.tests.factory import (
     UserFactory,
     UserWithGroupFactory,
 )
+from utils.utils import calculate_next_issue_date
+
+
+class GroupSerializerTests(APITestCase):
+    def setUp(self):
+        self.user = UserWithGroupFactory()
+        self.group = self.user.group_set.first()
+        self.newsletter = NewsletterFactory(
+            group=self.group,
+            questions=[QuestionFactory(group=self.group)],
+            status=Newsletter.Status.UPCOMING,
+        )
+        self.group_url = f"/groups/{self.group.id}/"
+        self.updated_group = {
+            "name": self.group.name,
+            "schedule": Group.Schedule.MONTHLY,
+            "active": self.group.active,
+            "logo_url": self.group.logo_url,
+            "last_issue_date": self.group.last_issue_date,
+        }
+        self.client.force_authenticate(user=self.user)
+
+    def test_update_group_schedule_updates_newsletter_issue_date(self):
+        previous_issue_date = self.newsletter.issue_date
+        predicted_new_date = calculate_next_issue_date(
+            self.updated_group["schedule"], datetime.date.today()
+        )
+        response = self.client.put(
+            self.group_url, data=self.updated_group, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["schedule"], self.updated_group["schedule"])
+        self.newsletter.refresh_from_db()
+        self.assertGreater(self.newsletter.issue_date, previous_issue_date)
+        self.assertEqual(self.newsletter.issue_date, predicted_new_date)
+
+    def test_update_group_schedule_updates_all_upcoming_newsletters(self):
+        upcoming_newsletters = [
+            self.newsletter,
+            NewsletterFactory(
+                group=self.group,
+                questions=[QuestionFactory(group=self.group)],
+                status=Newsletter.Status.UPCOMING,
+                issue_date=datetime.date.today()
+                + relativedelta.relativedelta(months=1),
+            ),
+        ]
+        response = self.client.put(
+            self.group_url, data=self.updated_group, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        previous_issue_date = datetime.date.today()
+        for newsletter in upcoming_newsletters:
+            predicted_new_date = calculate_next_issue_date(
+                self.updated_group["schedule"], previous_issue_date
+            )
+            newsletter.refresh_from_db()
+            self.assertEqual(predicted_new_date, newsletter.issue_date)
+            previous_issue_date = predicted_new_date
+
+    def test_update_group_schedule_updates_only_upcoming_newsletters(self):
+        non_upcoming_newsletters = []
+        for s in Newsletter.Status:
+            if s != Newsletter.Status.UPCOMING:
+                non_upcoming_newsletters.append(
+                    NewsletterFactory(
+                        group=self.group,
+                        questions=[QuestionFactory(group=self.group)],
+                        status=s,
+                    )
+                )
+        response = self.client.put(
+            self.group_url, data=self.updated_group, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for newsletter in non_upcoming_newsletters:
+            prev_issue_date = newsletter.issue_date
+            newsletter.refresh_from_db()
+            self.assertEqual(prev_issue_date, newsletter.issue_date)
 
 
 class GroupViewSetTests(APITestCase):

--- a/newsletters/serializers.py
+++ b/newsletters/serializers.py
@@ -34,10 +34,11 @@ class NewsletterCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         questions = validated_data.pop("questions")
         group = validated_data["group"]
+        last_newsletter = (
+            Newsletter.objects.filter(group_id=group.id).order_by("-issue_date").first()
+        )
         last_issue_date = (
-            group.last_issue_date.date()
-            if group.last_issue_date
-            else datetime.date.today()
+            datetime.date.today() if not last_newsletter else last_newsletter.issue_date
         )
 
         validated_data["issue_date"] = calculate_next_issue_date(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.7.2
 black==23.9.1
 certifi==2023.7.22
 click==8.1.7
-Django==4.2.7
+Django==4.2.6
 djangorestframework==3.14.0
 factory-boy==3.3.0
 Faker==19.13.0


### PR DESCRIPTION
- when we update a group's newsletter schedule, we should update all upcoming issues to reflect this change.
- Also added change where new newsletter creation dates are based off the latest newsletter in DB.